### PR TITLE
Add CI + Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,5 @@ jobs:
           make test
       - name: Compute code coverage
         run: |
+          pip3 install coverage
           make cover

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: GitHub Actions Demo
 on: [push]
 jobs:
-  Explore-GitHub-Actions:
+  ci:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
@@ -9,4 +9,7 @@ jobs:
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
       - name: Run unit tests
         run: |
-          python3 -m unittest
+          make test
+      - name: Compute code coverage
+        run: |
+          make cover

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: GitHub Actions Demo
+on: [push]
+jobs:
+  Explore-GitHub-Actions:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+      - name: List files in the repository
+        run: |
+          ls ${{ github.workspace }}
+      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,14 +4,9 @@ jobs:
   Explore-GitHub-Actions:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - name: Check out repository code
         uses: actions/checkout@v2
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
-      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
-      - name: List files in the repository
+      - name: Run unit tests
         run: |
-          ls ${{ github.workspace }}
-      - run: echo "🍏 This job's status is ${{ job.status }}."
+          python3 -m unittest

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.py[cod]
+.coverage

--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,5 @@ test:
 cover:
 	coverage run -m unittest discover && coverage report
 
-cover-report:
+cover-html:
 	coverage run -m unittest discover && coverage html -d htmlcov && open htmlcov/index.html

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ test:
 	python3 -m unittest
 
 cover:
-	coverage run -m unittest discover >& /dev/null && coverage report
+	coverage run -m unittest discover && coverage report
 
 cover-report:
-	coverage run -m unittest discover >& /dev/null && coverage html -d htmlcov && open htmlcov/index.html
+	coverage run -m unittest discover && coverage html -d htmlcov && open htmlcov/index.html

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: test
+
 test:
 	python3 -m unittest
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+test:
+	python3 -m unittest
+
+cover:
+	coverage run -m unittest discover >& /dev/null && coverage report
+
+cover-report:
+	coverage run -m unittest discover >& /dev/null && coverage html -d htmlcov && open htmlcov/index.html


### PR DESCRIPTION
This PR:
- Adds CI to the repository using GitHub Actions. The CI pipeline runs unit tests and generates a code coverage report.

See a sample CI pipeline execution here:
![Screen Shot 2022-02-20 at 11 29 28 PM](https://user-images.githubusercontent.com/12554095/154908377-85958ee4-586c-4634-af00-cecaac8140ed.png)

https://github.com/veeral-patel/wordle-solver/runs/5270506138?check_suite_focus=true

- Creates a Makefile which can be used to run tests and compute code coverage with `make test` and `make cover` respectively. This way no one needs to memorize any commands.

(Note you may need to install `coverage` with `pip3 install coverage`)

- In addition, make `cover-report` opens a HTML UI with coverage data, broken down by line, as you can see here:

![Screen Shot 2022-02-20 at 11 31 10 PM](https://user-images.githubusercontent.com/12554095/154908592-1752c363-d0cf-47c8-bbb1-4134be5785c5.png) 